### PR TITLE
testing defaults to per-env

### DIFF
--- a/gitops-promotion.yaml
+++ b/gitops-promotion.yaml
@@ -1,3 +1,4 @@
+prflow: per-env
 environments:
   - name: dev
     auto: true


### PR DESCRIPTION
This is to match https://github.com/XenitAB/gitops-promotion/pull/136. This model does not really fly; config should be written by tests so they don't trip each other up. Let's hope we won't need to run tests for main until that PR is merged.